### PR TITLE
Fix for build issue with platformio and ESP-IDF v5.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,7 @@ jobs:
       fail-fast: false
       matrix:
         # ESP-IDF versions and targets
-        idf_ver: [ v4.1, v4.2, v4.3, v4.4 ]
+        idf_ver: [ v4.1, v4.2, v4.3, v4.4, v5.0 ]
         idf_target: [ esp32, esp32s2, esp32s3, esp32c3, esp32h2 ]
         # Filter out unsupported combinations
         exclude:

--- a/src/double_reset.c
+++ b/src/double_reset.c
@@ -2,6 +2,7 @@
 #include <esp_log.h>
 #include <freertos/FreeRTOS.h>
 #include <freertos/event_groups.h>
+#include <inttypes.h>
 #include <nvs.h>
 
 static const char TAG[] = "double_reset";
@@ -186,7 +187,7 @@ esp_err_t double_reset_start(bool *result, uint32_t timeout_ms)
 
         // Store timeout
         double_reset_timeout = timeout_ms;
-        ESP_LOGI(TAG, "double reset flag set, waiting for %d ms", timeout_ms);
+        ESP_LOGI(TAG, "double reset flag set, waiting for %" PRIu32 " ms", timeout_ms);
 
         // Create background task, that resets the status
         BaseType_t ret = xTaskCreate(double_reset_task, "double_reset", 2048, NULL, tskIDLE_PRIORITY + 1, NULL);


### PR DESCRIPTION
Pull request fix: https://github.com/mdvorak/esp-double-reset/issues/6

build: add ESP-IDF v5.0 to build matrix for GitHub CI
fix: 🚨 Adjust the format strings to use format specifiers from inttypes.h, for example PRIu32 for uint32_